### PR TITLE
allowing cuda to make the call

### DIFF
--- a/ErrorPredictorMSA.py
+++ b/ErrorPredictorMSA.py
@@ -45,7 +45,7 @@ def main():
     parser.add_argument("--gpu",
                         "-g", action="store",
                         default=None,
-                        help="specific gpu id to use")
+                        help="specific gpu id to use, e.g. 0 for gpu0 (Default: None)")
     parser.add_argument("--featurize",
                         "-f",
                         action="store_true",
@@ -124,7 +124,7 @@ def main():
     # Importing larger libraries #
     ##############################
     os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-    if args.gpu:
+    if args.gpu is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
     script_dir = os.path.dirname(__file__)
     sys.path.insert(0, script_dir)

--- a/ErrorPredictorMSA.py
+++ b/ErrorPredictorMSA.py
@@ -44,9 +44,8 @@ def main():
                         help="# of cpus to use for featurization (Default: 1)")
     parser.add_argument("--gpu",
                         "-g", action="store",
-                        type=int,
-                        default=0,
-                        help="gpu device to use (default gpu0)")
+                        default=None,
+                        help="specific gpu id to use")
     parser.add_argument("--featurize",
                         "-f",
                         action="store_true",
@@ -125,7 +124,8 @@ def main():
     # Importing larger libraries #
     ##############################
     os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+    if args.gpu:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
     script_dir = os.path.dirname(__file__)
     sys.path.insert(0, script_dir)
     import pyErrorPred


### PR DESCRIPTION
In case the user doesn't specify a GPU ID, the default shouldn't be 0, but instead Cuda should decide how to handle the workload. Else when you run this in parallel / when other people run something on this GPU, you'll just get an OOM error even when another GPU core is idle.
This was a problem for me when I used RoseTTAFold, which uses this code. 